### PR TITLE
Circumvent a bug in LinearOperators

### DIFF
--- a/src/GradientOp.jl
+++ b/src/GradientOp.jl
@@ -30,9 +30,10 @@ function GradientOpImpl(T::Type, shape::NTuple{N,Int64}, dim::Integer) where N
   nrow = div( (shape[dim]-1)*prod(shape), shape[dim] )
   ncol = prod(shape)
   return LinearOperator{T}(nrow, ncol, false, false,
-                          (res,x) -> (grad!(res,x,shape,dim) ),
-                          (res,x) -> (grad_t!(res,x,shape,dim) ),
-                          nothing )
+                          (res,x) -> (grad!(res,x,shape,dim)),
+                          (res,x) -> (grad_t!(res,x,shape,dim)),
+                          (res,x) -> (grad_t!(res,x,shape,dim))
+                          )
 end
 
 # directional gradients


### PR DESCRIPTION
Circumvents the bug https://github.com/JuliaSmoothOptimizers/LinearOperators.jl/issues/302 in LinearOperators – and once the bug is fixed, it prevents a bunch of allocations and conjugations. 