### PR TITLE
DiagOp not working with @view on linear operator

### DIFF
--- a/src/DiagOp.jl
+++ b/src/DiagOp.jl
@@ -53,7 +53,7 @@ function DiagOp(ops)
                      (res,y) -> (diagOpTProd(res,y,ncol,yIdx,xIdx,ops)),
                      (res,y) -> (diagOpCTProd(res,y,ncol,yIdx,xIdx,ops)),
                      0, 0, 0, false, false, false, S(undef, 0), S(undef, 0),
-                     [ops...], false, xIdx, yIdx)
+                     ops, false, xIdx, yIdx)
 
   return Op
 end

--- a/test/testOperators.jl
+++ b/test/testOperators.jl
@@ -317,6 +317,8 @@ function testDiagOp(N=32,K=2;arrayType = Array)
   op1 = DiagOp(blocks)
   op2 = DiagOp(blocks...)
   op3 = DiagOp(block, K)
+  op4 = DiagOp(@view blocks[1:K])
+
 
   # Operations
   @testset "Diag Prod" begin
@@ -324,10 +326,14 @@ function testDiagOp(N=32,K=2;arrayType = Array)
     y1 = Array(op1 * x)
     y2 = Array(op2 * x)
     y3 = Array(op3 * x)
+    y4 = Array(op4 * x)
+
 
     @test y ≈ y1 rtol = 1e-2
     @test y1 ≈ y2 rtol = 1e-2
     @test y2 ≈ y3 rtol = 1e-2
+    @test y4 ≈ y1 rtol = 1e-2
+
   end
 
   @testset "Diag Transpose" begin
@@ -335,10 +341,12 @@ function testDiagOp(N=32,K=2;arrayType = Array)
     y1 = Array(transpose(op1) * x)
     y2 = Array(transpose(op2) * x)
     y3 = Array(transpose(op3) * x)
+    y4 = Array(transpose(op4) * x)
 
     @test y ≈ y1 rtol = 1e-2
     @test y1 ≈ y2 rtol = 1e-2
     @test y2 ≈ y3 rtol = 1e-2
+    @test y4 ≈ y1 rtol = 1e-2
   end
 
   @testset "Diag Adjoint" begin
@@ -346,10 +354,12 @@ function testDiagOp(N=32,K=2;arrayType = Array)
     y1 = Array(adjoint(op1) * x)
     y2 = Array(adjoint(op2) * x)
     y3 = Array(adjoint(op3) * x)
+    y4 = Array(adjoint(op4) * x)
 
     @test y ≈ y1 rtol = 1e-2
     @test y1 ≈ y2 rtol = 1e-2
     @test y2 ≈ y3 rtol = 1e-2
+    @test y4 ≈ y1 rtol = 1e-2
   end
 
   @testset "Diag Normal" begin
@@ -357,10 +367,13 @@ function testDiagOp(N=32,K=2;arrayType = Array)
     y1 = Array(normalOperator(op1) * x)
     y2 = Array(normalOperator(op2) * x)
     y3 = Array(normalOperator(op3) * x)
+    y4 = Array(normalOperator(op4) * x)
 
     @test y ≈ y1 rtol = 1e-2
     @test y1 ≈ y2 rtol = 1e-2
     @test y2 ≈ y3 rtol = 1e-2
+    @test y4 ≈ y1 rtol = 1e-2
+
   end
 
   @testset "Weighted Diag Normal" begin
@@ -369,15 +382,19 @@ function testDiagOp(N=32,K=2;arrayType = Array)
     prod1 = ProdOp(wop, op1)
     prod2 = ProdOp(wop, op2)
     prod3 = ProdOp(wop, op3)
+    prod4 = ProdOp(wop, op4)
 
     y = Array(adjoint(F) * adjoint(wop) * wop * F* x)
     y1 = Array(normalOperator(prod1) * x)
     y2 = Array(normalOperator(prod2) * x)
     y3 = Array(normalOperator(prod3) * x)
+    y4 = Array(normalOperator(prod4) * x)
 
     @test y ≈ y1 rtol = 1e-2
     @test y1 ≈ y2 rtol = 1e-2
     @test y2 ≈ y3 rtol = 1e-2
+    @test y4 ≈ y1 rtol = 1e-2
+
   end
 
 end


### PR DESCRIPTION
Hi,

We had the issue that we wanted to use DiagOp with a view on a list of linear operators, see the example below.
This unfortunately created a type inconsistency between `typeof(ops)` and `typeof([ops...]`. The first one is of type `SubArray{LinearOperator...}` while the second one is of type `Vector{LinearOperator...}`.

If I'm not mistaken, `[ops...]` creates a copy of the operator which can be quite costly if the operators are large. So it would be better to avoid this. 

I'm unsure though if this change causes issues somewhere else especially since we do not create a copy. 

Best,
Sebastian

Example:
```
N=32
K=4
arrayType = Array
x = arrayType(rand(ComplexF64, K*N))
block = arrayType(rand(ComplexF64, N, N))

F = arrayType(zeros(ComplexF64, K*N, K*N))
for k = 1:K
    start = (k-1)*N + 1
    stop = k*N
    F[start:stop,start:stop] = block
end

blocks = [block for k = 1:K]
op1 = DiagOp(blocks[1:2])
op2 = DiagOp(@view blocks[1:2]) # this line doesn't work with the current version
```