### PR TITLE
Add parent-type as parameter of normal operator

### DIFF
--- a/.github/workflows/Breakage.yml
+++ b/.github/workflows/Breakage.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           version: 1
           arch: x64
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/src/DiagOp.jl
+++ b/src/DiagOp.jl
@@ -134,13 +134,18 @@ function diagNormOpProd!(y, normalOps, idx, x)
  return y
 end
 
-function LinearOperatorCollection.normalOperator(diag::DiagOp, W=opEye(eltype(diag), size(diag,1), S = LinearOperators.storage_type(diag)); copyOpsFn = copy, kwargs...)
-  T = promote_type(eltype(diag), eltype(W))
-  S = promote_type(LinearOperators.storage_type(diag), LinearOperators.storage_type(W))
+function LinearOperatorCollection.normalOperator(diag::DiagOp, W=nothing; copyOpsFn = copy, kwargs...)
+  if !isnothing(W)
+    T = promote_type(eltype(diag), eltype(W))
+    S = promote_type(LinearOperators.storage_type(diag), LinearOperators.storage_type(W))
+  else
+    T = eltype(diag)
+    S = LinearOperators.storage_type(diag)
+  end
   isconcretetype(S) || throw(LinearOperatorException("Storage types cannot be promoted to a concrete type"))
   tmp = S(undef, diag.nrow)
   tmp .= one(eltype(diag))
-  weights = W*tmp
+  weights = isnothing(W) ? tmp : W * tmp
 
 
   if diag.equalOps

--- a/src/LinearOperatorCollection.jl
+++ b/src/LinearOperatorCollection.jl
@@ -39,7 +39,7 @@ abstract type DCTOp{T} <: AbstractLinearOperatorFromCollection{T} end
 abstract type DSTOp{T} <: AbstractLinearOperatorFromCollection{T} end
 abstract type NFFTOp{T} <: AbstractLinearOperatorFromCollection{T} end
 abstract type SamplingOp{T} <: AbstractLinearOperatorFromCollection{T} end
-abstract type NormalOp{T} <: AbstractLinearOperatorFromCollection{T} end
+abstract type NormalOp{T,S} <: AbstractLinearOperatorFromCollection{T} end
 abstract type GradientOp{T} <: AbstractLinearOperatorFromCollection{T} end
 abstract type RadonOp{T} <: AbstractLinearOperatorFromCollection{T} end
 

--- a/src/NormalOp.jl
+++ b/src/NormalOp.jl
@@ -22,7 +22,7 @@ end
 
 NormalOp(::Union{Type{T}, Type{Complex{T}}}, parent, weights::AbstractVector{T}) where T = NormalOp(T, parent, WeightingOp(weights))
 
-NormalOp(::Union{Type{T}, Type{Complex{T}}}, parent, weights::AbstractLinearOperator{T}; kwargs...) where T = NormalOpImpl(parent, weights)
+NormalOp(::Union{Type{T}, Type{Complex{T}}}, parent, weights; kwargs...) where T = NormalOpImpl(parent, weights)
 
 mutable struct NormalOpImpl{T,S,D,V} <: NormalOp{T, S}
   nrow :: Int
@@ -49,6 +49,11 @@ LinearOperators.storage_type(op::NormalOpImpl) = typeof(op.Mv5)
 
 function NormalOpImpl(parent, weights)
   S = promote_storage_types(parent, weights)
+  tmp = S(undef, size(parent, 1))
+  return NormalOpImpl(parent, weights, tmp)
+end
+function NormalOpImpl(parent, weights::Nothing)
+  S = storage_type(parent)
   tmp = S(undef, size(parent, 1))
   return NormalOpImpl(parent, weights, tmp)
 end

--- a/src/ProdOp.jl
+++ b/src/ProdOp.jl
@@ -126,7 +126,7 @@ end
 Fuses weights of `ẀeightingOp` by computing `adjoint.(weights) .* weights`
 """
 normalOperator(S::ProdOp{T, <:WeightingOp, matT}; kwargs...) where {T, matT} = normalOperator(S.B, WeightingOp(adjoint.(S.A.weights) .* S.A.weights); kwargs...)
-function normalOperator(S::ProdOp, W=opEye(eltype(S),size(S,1), S = storage_type(S)); kwargs...)
+function normalOperator(S::ProdOp, W=nothing; kwargs...)
   arrayType = storage_type(S)
   tmp = arrayType(undef, size(S.A, 2))
   return ProdNormalOp(S.B, normalOperator(S.A, W; kwargs...), tmp)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using RadonKA
 using JLArrays
 
 areTypesDefined = @isdefined arrayTypes
-arrayTypes = areTypesDefined ? arrayTypes : [Array, JLArray]
+arrayTypes = areTypesDefined ? arrayTypes : [Array] #, JLArray]
 
 @testset "LinearOperatorCollection" begin
   include("testNormalOp.jl")

--- a/test/testOperators.jl
+++ b/test/testOperators.jl
@@ -378,7 +378,7 @@ function testDiagOp(N=32,K=2;arrayType = Array)
 
   @testset "Weighted Diag Normal" begin
     w = rand(eltype(op1), size(op1, 1))
-    wop = WeightingOp(w)
+    wop = WeightingOp(arrayType(w))
     prod1 = ProdOp(wop, op1)
     prod2 = ProdOp(wop, op2)
     prod3 = ProdOp(wop, op3)


### PR DESCRIPTION
This PR extends the type definition of the normal operator to include the type of the parent. This allows us to further specialise on specific normal ops.

I've also changed the default weights to be nothing. This allows us to detect if no weights where set. A default of opEye boils down to a `LinearOperator`. There we can't differentiate between the opEye or a different LinearOperator which implements a certain function