### PR TITLE
Exchangable NFFT backends

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ julia = "1.9"
 GPUArrays = "11"
 KernelAbstractions = "0.9"
 JLArrays = "0.2"
-NFFT = "0.13"
+AbstractNFFTs = "0.9"
 LinearOperators = "2"
 RadonKA = "0.6"
 Wavelets = "0.9, 0.10"
@@ -32,6 +32,7 @@ Reexport = "1.0"
 FFTW = "1.0"
 
 [weakdeps]
+AbstractNFFTs = "7f219486-4aa7-41d6-80a7-e08ef20ceed7"
 GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 NFFT = "efe261a4-0d2b-5849-be55-fc731d526b0d"
@@ -43,7 +44,7 @@ RadonKA = "86de8297-835b-47df-b249-c04e8db91db5"
 test = ["Test", "FFTW", "Wavelets", "NFFT", "JLArrays", "RadonKA"]
 
 [extensions]
-LinearOperatorNFFTExt = ["NFFT", "FFTW"]
+LinearOperatorNFFTExt = ["AbstractNFFTs", "FFTW"]
 LinearOperatorFFTWExt = "FFTW"
 LinearOperatorWaveletExt = "Wavelets"
 LinearOperatorGPUArraysExt = "GPUArrays"

--- a/ext/LinearOperatorNFFTExt/LinearOperatorNFFTExt.jl
+++ b/ext/LinearOperatorNFFTExt/LinearOperatorNFFTExt.jl
@@ -1,6 +1,6 @@
 module LinearOperatorNFFTExt
 
-using LinearOperatorCollection, NFFT, NFFT.AbstractNFFTs, FFTW, FFTW.AbstractFFTs
+using LinearOperatorCollection, AbstractNFFTs, FFTW, FFTW.AbstractFFTs
 
 include("NFFTOp.jl")
 

--- a/ext/LinearOperatorNFFTExt/NFFTOp.jl
+++ b/ext/LinearOperatorNFFTExt/NFFTOp.jl
@@ -41,7 +41,7 @@ LinearOperators.storage_type(op::NFFTOpImpl) = typeof(op.Mv5)
 function NFFTOpImpl(shape::Tuple, tr::AbstractMatrix{T}; toeplitz=false, oversamplingFactor=1.25, kernelSize=3, S = Vector{Complex{T}}, kargs...) where {T}
 
   baseArrayType = Base.typename(S).wrapper # https://github.com/JuliaLang/julia/issues/35543
-  plan = plan_nfft(baseArrayType, tr, shape, m=kernelSize, σ=oversamplingFactor, precompute=NFFT.TENSOR,
+  plan = plan_nfft(baseArrayType, tr, shape, m=kernelSize, σ=oversamplingFactor, # precompute=AbstractNFFTs.TENSOR,
 		                          fftflags=FFTW.ESTIMATE, blocking=true)
 
   return NFFTOpImpl{eltype(S), S, typeof(plan)}(size(tr,2), prod(shape), false, false

--- a/ext/LinearOperatorNFFTExt/NFFTOp.jl
+++ b/ext/LinearOperatorNFFTExt/NFFTOp.jl
@@ -8,7 +8,7 @@ generates a `NFFTOpImpl` which evaluates the MRI Fourier signal encoding operato
 * `shape::NTuple{D,Int64}`  - size of image to encode/reconstruct
 * `tr`                      - Either a `Trajectory` object, or a `ND x Nsamples` matrix for an ND-dimenensional (e.g. 2D or 3D) NFFT with `Nsamples` k-space samples
 * (`nodes=nothing`)         - Array containg the trajectory nodes (redundant)
-* (`kargs`)                 - additional keyword arguments
+* (`kargs`)                 - additional keyword arguments for the NFFT plan
 """
 function LinearOperatorCollection.NFFTOp(::Type{T};
     shape::Tuple, nodes::AbstractMatrix{U}, toeplitz=false, oversamplingFactor=1.25, 
@@ -41,8 +41,8 @@ LinearOperators.storage_type(op::NFFTOpImpl) = typeof(op.Mv5)
 function NFFTOpImpl(shape::Tuple, tr::AbstractMatrix{T}; toeplitz=false, oversamplingFactor=1.25, kernelSize=3, S = Vector{Complex{T}}, kargs...) where {T}
 
   baseArrayType = Base.typename(S).wrapper # https://github.com/JuliaLang/julia/issues/35543
-  plan = plan_nfft(baseArrayType, tr, shape, m=kernelSize, σ=oversamplingFactor, # precompute=AbstractNFFTs.TENSOR,
-		                          fftflags=FFTW.ESTIMATE, blocking=true)
+  plan = plan_nfft(baseArrayType, tr, shape, m=kernelSize, σ=oversamplingFactor,
+		                          fftflags=FFTW.ESTIMATE, blocking=true, kargs...)
 
   return NFFTOpImpl{eltype(S), S, typeof(plan)}(size(tr,2), prod(shape), false, false
             , (res,x) -> produ!(res,plan,x)


### PR DESCRIPTION
This PR uses the exchangable AbstractNFFTs PR to allow the NFFTOperator to be defined with different NFFT providers such as NonuniformFFTs:

```julia
julia> using NonuniformFFTs, LinearOperatorCollection

# setup parameters

julia> nop = NFFTOp(ComplexF64; shape=(N,N), nodes, symmetrize=false, S = typeof(xop))

julia> typeof(nop.plan)
NonuniformFFTs.NFFTPlan{Float64, 2, PlanNUFFT{ComplexF64, 2, 1, 3, CPU, ...})
```